### PR TITLE
NumixDark theme: Fix background color when creating a group

### DIFF
--- a/src/themes/numix_dark.css
+++ b/src/themes/numix_dark.css
@@ -101,6 +101,10 @@
   background: #333333 !important;
 }
 
+.new-group-search, .new-group-contacts, .drawer-section-main {
+  background: #333333;
+}
+
 
 /* Search bar and right sidebar */
 


### PR DESCRIPTION
Missed this one when creating the them. Creating a group displays a white background which stands out really badly.