### PR TITLE
Use full PGP fingerprint and use apt-key adv to add key

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,8 +68,7 @@ You can also use `apt-get` (recommended):
 
 ```
 # Download my gpg key to make sure the deb you download is correct
-gpg --keyserver pool.sks-keyservers.net --recv-keys 1537994D
-gpg --export --armor 1537994D | sudo apt-key add -
+sudo apt-key adv --keyserver pool.sks-keyservers.net --recv 6DDA23616E3FE905FFDA152AE61DA9241537994D
 
 # Add my repository to your sources list (skip if you've done this already)
 # Replace <channel> with stable, beta or dev (pick stable if you're unsure)


### PR DESCRIPTION
Using short key ids is considered insecure.

See https://lkml.org/lkml/2016/8/15/445 as an example of a short key id collission in the wild.