### PR TITLE
[Numix Dark] Hide all tail-containers

### DIFF
--- a/src/themes/numix_dark.css
+++ b/src/themes/numix_dark.css
@@ -258,7 +258,7 @@ header.pane-chat-header {
 /* Chat bubble */
 
 /* Hide the tail since its just an image */
-.message-out>.tail-container, .message-in>.tail-container {
+.tail-container {
   display: none;
 }
 


### PR DESCRIPTION
Noticed that the latest version of Whatsapp was showing tail containers again. This CSS fix should fix the issue.